### PR TITLE
G1 affine scalar mul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ codec = { package = "parity-scale-codec", version = "3.2.2", default-features = 
 ark-ec = { version = "0.4.2", default-features = false }
 ark-bls12-381 = { version = "0.4.0",features = [ "curve" ], default-features = false }
 ark-std = { version = "0.4.0", default-features = false }
+num-bigint = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 csv = ">= 1.0, < 1.2" # csv 1.2 has MSRV 1.60

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,3 +89,6 @@ pub(crate) use digest::generic_array;
 
 #[cfg(feature = "experimental")]
 pub mod hash_to_curve;
+
+const HOST_CALL: ark_scale::Usage = ark_scale::HOST_CALL;
+pub type ArkScale<T> = ark_scale::ArkScale<T, HOST_CALL>;

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -2,8 +2,9 @@ use crate::fp::Fp;
 use crate::fp12::Fp12;
 use crate::fp2::Fp2;
 use crate::fp6::Fp6;
-use crate::{G1Affine, G1Projective, G2Affine, G2Projective, Scalar, BLS_X, BLS_X_IS_NEGATIVE};
-
+use crate::{
+    ArkScale, G1Affine, G1Projective, G2Affine, G2Projective, Scalar, BLS_X, BLS_X_IS_NEGATIVE,
+};
 use codec::{Decode, Encode};
 use core::borrow::Borrow;
 use core::fmt;
@@ -22,9 +23,6 @@ use pairing::MultiMillerLoop;
 /// Represents results of a Miller loop, one of the most expensive portions
 /// of the pairing function. `MillerLoopResult`s cannot be compared with each
 /// other until `.final_exponentiation()` is called, which is also expensive.
-
-const HOST_CALL: ark_scale::Usage = ark_scale::HOST_CALL;
-pub type ArkScale<T> = ark_scale::ArkScale<T, HOST_CALL>;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "pairings")))]
 #[derive(Copy, Clone, Debug)]
@@ -133,30 +131,30 @@ impl MillerLoopResult {
             0: Fp12 {
                 c0: Fp6 {
                     c0: Fp2 {
-                        c0: Fp(result.0.c0.c0.c0.0.0),
-                        c1: Fp(result.0.c0.c0.c1.0.0),
+                        c0: Fp(result.0.c0.c0.c0.0 .0),
+                        c1: Fp(result.0.c0.c0.c1.0 .0),
                     },
                     c1: Fp2 {
-                        c0: Fp(result.0.c0.c1.c0.0.0),
-                        c1: Fp(result.0.c0.c1.c1.0.0),
+                        c0: Fp(result.0.c0.c1.c0.0 .0),
+                        c1: Fp(result.0.c0.c1.c1.0 .0),
                     },
                     c2: Fp2 {
-                        c0: Fp(result.0.c0.c2.c0.0.0),
-                        c1: Fp(result.0.c0.c2.c1.0.0),
+                        c0: Fp(result.0.c0.c2.c0.0 .0),
+                        c1: Fp(result.0.c0.c2.c1.0 .0),
                     },
                 },
                 c1: Fp6 {
                     c0: Fp2 {
-                        c0: Fp(result.0.c1.c0.c0.0.0),
-                        c1: Fp(result.0.c1.c0.c1.0.0),
+                        c0: Fp(result.0.c1.c0.c0.0 .0),
+                        c1: Fp(result.0.c1.c0.c1.0 .0),
                     },
                     c1: Fp2 {
-                        c0: Fp(result.0.c1.c1.c0.0.0),
-                        c1: Fp(result.0.c1.c1.c1.0.0),
+                        c0: Fp(result.0.c1.c1.c0.0 .0),
+                        c1: Fp(result.0.c1.c1.c1.0 .0),
                     },
                     c2: Fp2 {
-                        c0: Fp(result.0.c1.c2.c0.0.0),
-                        c1: Fp(result.0.c1.c2.c1.0.0),
+                        c0: Fp(result.0.c1.c2.c0.0 .0),
+                        c1: Fp(result.0.c1.c2.c1.0 .0),
                     },
                 },
             },


### PR DESCRIPTION
Replaces Affine multiplication on g1 with Substrate host function.

- We need to perform Montomery reduction on the scalars to bring them into arkworks form
- It is probably non-optimal to convert to arkworks Affine first before performing conversion to ZCash Affine and afterwards back to ZCash Projective. Direct conversion Arkworks -> ZCash failed, probably also due to different representations.