### PR TITLE
use fastcrypto to convert into Affine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ ark-ec = { version = "0.4.2", default-features = false }
 ark-bls12-381 = { version = "0.4.0",features = [ "curve" ], default-features = false }
 ark-std = { version = "0.4.0", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto" }
 
 [dev-dependencies]
 csv = ">= 1.0, < 1.2" # csv 1.2 has MSRV 1.60


### PR DESCRIPTION
Use fastcrypto-zkp to convert into arkworks G1Affine point.

Could also be useful to convert from ZCash Projective -> arkworks Projective.